### PR TITLE
Revert from node:8 to node:8-jessie for libpng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ## Using a smaller image like Alpine does
 ## not work because of missing dependencies
 ## to libpng
-FROM node:8
+FROM node:8-jessie
 
 WORKDIR /app
 COPY package.json ./


### PR DESCRIPTION
Based on this issue: https://github.com/nodejs/docker-node/issues/945